### PR TITLE
Remove kohana-test-bootsrap, replace with kohana-test-bootstrap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "openbuildings/environment-backup": "0.1.*"
     },
     "require-dev": {
-        "se/selenium-server-standalone": "^2.43",
-        "openbuildings/kohana-test-bootstrap": "0.2.*"
+        "se/selenium-server-standalone": "^2.43"
     },
     "autoload": {
         "psr-0": {"Openbuildings\\PHPUnitSpiderling\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "openbuildings/environment-backup": "0.1.*"
     },
     "require-dev": {
-        "openbuildings/kohana-test-bootsrap": "0.1.*",
-        "se/selenium-server-standalone": "^2.43"
+        "se/selenium-server-standalone": "^2.43",
+        "openbuildings/kohana-test-bootstrap": "0.2.*"
     },
     "autoload": {
         "psr-0": {"Openbuildings\\PHPUnitSpiderling\\": "src/"}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "94b983f166a8cbd7e715116fcf052a86",
+    "content-hash": "f16f2629ebb0b39d3ebb5e882673d9fe",
     "packages": [
         {
             "name": "openbuildings/environment-backup",
@@ -141,106 +141,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "kohana/core",
-            "version": "v3.3.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kohana/core.git",
-                "reference": "bdbe81afb5a09cee4269d2e2210a0d293265231a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kohana/core/zipball/bdbe81afb5a09cee4269d2e2210a0d293265231a",
-                "reference": "bdbe81afb5a09cee4269d2e2210a0d293265231a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "kohana/koharness": "*@dev",
-                "kohana/unittest": "3.3.*@dev"
-            },
-            "suggest": {
-                "ext-curl": "*",
-                "ext-http": "*",
-                "ext-mcrypt": "*"
-            },
-            "type": "library",
-            "extra": {
-                "installer-paths": {
-                    "vendor/{$vendor}/{$name}": [
-                        "type:kohana-module"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-3.3/develop": "3.3.x-dev",
-                    "dev-3.4/develop": "3.4.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Kohana Team",
-                    "email": "team@kohanaframework.org",
-                    "homepage": "http://kohanaframework.org/team",
-                    "role": "developer"
-                }
-            ],
-            "description": "Core system classes for the Kohana application framework",
-            "homepage": "http://kohanaframework.org",
-            "keywords": [
-                "framework",
-                "kohana"
-            ],
-            "time": "2016-07-25 13:15:13"
-        },
-        {
-            "name": "openbuildings/kohana-test-bootstrap",
-            "version": "0.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/OpenBuildings/kohana-test-bootstrap.git",
-                "reference": "83b9e254f385b907c859b8332e4396b151a7e80e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/OpenBuildings/kohana-test-bootstrap/zipball/83b9e254f385b907c859b8332e4396b151a7e80e",
-                "reference": "83b9e254f385b907c859b8332e4396b151a7e80e",
-                "shasum": ""
-            },
-            "require": {
-                "kohana/core": "^3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Ivan Kerin",
-                    "email": "ikerin@gmail.com",
-                    "role": "Author"
-                },
-                {
-                    "name": "Haralan Dobrev",
-                    "email": "hkdobrev@gmail.com",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "Helper package for testing Kohana modules",
-            "time": "2016-07-28 14:07:23"
-        },
         {
             "name": "se/selenium-server-standalone",
             "version": "v2.46.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5900f99afb48017ed1e1dd286c683d43",
-    "content-hash": "87fd3fc58b7b79057e2f90c51efe0157",
+    "content-hash": "94b983f166a8cbd7e715116fcf052a86",
     "packages": [
         {
             "name": "openbuildings/environment-backup",
@@ -143,18 +142,79 @@
     ],
     "packages-dev": [
         {
-            "name": "openbuildings/kohana-test-bootsrap",
-            "version": "0.1.2",
+            "name": "kohana/core",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/OpenBuildings/kohana-test-bootstrap.git",
-                "reference": "57c9cae9bd97edbe58d1c41c35c499c7d54f4030"
+                "url": "https://github.com/kohana/core.git",
+                "reference": "bdbe81afb5a09cee4269d2e2210a0d293265231a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenBuildings/kohana-test-bootstrap/zipball/57c9cae9bd97edbe58d1c41c35c499c7d54f4030",
-                "reference": "57c9cae9bd97edbe58d1c41c35c499c7d54f4030",
+                "url": "https://api.github.com/repos/kohana/core/zipball/bdbe81afb5a09cee4269d2e2210a0d293265231a",
+                "reference": "bdbe81afb5a09cee4269d2e2210a0d293265231a",
                 "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "kohana/koharness": "*@dev",
+                "kohana/unittest": "3.3.*@dev"
+            },
+            "suggest": {
+                "ext-curl": "*",
+                "ext-http": "*",
+                "ext-mcrypt": "*"
+            },
+            "type": "library",
+            "extra": {
+                "installer-paths": {
+                    "vendor/{$vendor}/{$name}": [
+                        "type:kohana-module"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-3.3/develop": "3.3.x-dev",
+                    "dev-3.4/develop": "3.4.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kohana Team",
+                    "email": "team@kohanaframework.org",
+                    "homepage": "http://kohanaframework.org/team",
+                    "role": "developer"
+                }
+            ],
+            "description": "Core system classes for the Kohana application framework",
+            "homepage": "http://kohanaframework.org",
+            "keywords": [
+                "framework",
+                "kohana"
+            ],
+            "time": "2016-07-25 13:15:13"
+        },
+        {
+            "name": "openbuildings/kohana-test-bootstrap",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/OpenBuildings/kohana-test-bootstrap.git",
+                "reference": "83b9e254f385b907c859b8332e4396b151a7e80e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/OpenBuildings/kohana-test-bootstrap/zipball/83b9e254f385b907c859b8332e4396b151a7e80e",
+                "reference": "83b9e254f385b907c859b8332e4396b151a7e80e",
+                "shasum": ""
+            },
+            "require": {
+                "kohana/core": "^3.3"
             },
             "type": "library",
             "autoload": {
@@ -169,13 +229,17 @@
             "authors": [
                 {
                     "name": "Ivan Kerin",
-                    "email": "ivan@openbuildings.com",
-                    "homepage": "https://github.com/OpenBuildings/jam",
+                    "email": "ikerin@gmail.com",
                     "role": "Author"
+                },
+                {
+                    "name": "Haralan Dobrev",
+                    "email": "hkdobrev@gmail.com",
+                    "role": "Maintainer"
                 }
             ],
-            "description": "Kohana core classes repackaged with composer, used to test modules",
-            "time": "2013-10-01 08:57:54"
+            "description": "Helper package for testing Kohana modules",
+            "time": "2016-07-28 14:07:23"
         },
         {
             "name": "se/selenium-server-standalone",


### PR DESCRIPTION
Creating new PR to do this easy fix, which resolves this Composer warning:

> Package openbuildings/kohana-test-bootsrap is abandoned, you should avoid using it. Use openbuildings/kohana-test-bootstrap instead.

I'm creating a PR to get a Travis build for this change.

There are some Composer updates available, let me know if you want a PR for those as well.
